### PR TITLE
bump pyproject version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyquil-for-azure-quantum"
-version = "0.0.3"
+version = "0.1.0"
 description = "Run Quil programs on Microsoft Azure Quantum using pyQuil"
 authors = ["Dylan Anthony <danthony@rigetti.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
The version must be bumped manually since there is no tooling in this repo (e.g. `knope`) to do so automatically.